### PR TITLE
Update .gitignore to ignore bin files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+
+# ignore bin folders' contents, except data folder therein
+/bin/*
+!/bin/data/
+
 # Some general ignore patterns
 build/
 obj/


### PR DESCRIPTION
Compiling the simple PG dirtied the submodule within OF because the binaries were not ignored properly. See openframeworks/openFrameworks#1672.
