### PR TITLE
Set fixed framerate [fix bug #3095]

### DIFF
--- a/src/testApp.cpp
+++ b/src/testApp.cpp
@@ -123,7 +123,7 @@ void testApp::setup(){
     ofEnableAlphaBlending();
     ofSetLogLevel(OF_LOG_VERBOSE);
     ofSetVerticalSync(true);
-
+    ofSetFramerate(60);
     
     statusEnergy = 0;
     


### PR DESCRIPTION
If a window loses focus in OSX, it no longer receives VSYNC events. If ofSetFrameRate() has not been called, it will no longer be frame rate limited. This can cause unwanted behaviour, such as the application maxing out CPU usage.

See: https://github.com/openframeworks/openFrameworks/issues/3095
