### PR TITLE
Fix syntax error when setting frame rate

### DIFF
--- a/src/testApp.cpp
+++ b/src/testApp.cpp
@@ -123,7 +123,7 @@ void testApp::setup(){
     ofEnableAlphaBlending();
     ofSetLogLevel(OF_LOG_VERBOSE);
     ofSetVerticalSync(true);
-    ofSetFramerate(60);
+    ofSetFrameRate(60);
     
     statusEnergy = 0;
     


### PR DESCRIPTION
dacaadf642271d143804b92c6f80db67dd11dc1c introduced a syntax error, small "r" in `ofSetFrameRate()`.
