### PR TITLE
support for ADDON_PURECFLAGS variable for Pure C (not C++) flag

### DIFF
--- a/projectGenerator.xcodeproj/project.pbxproj
+++ b/projectGenerator.xcodeproj/project.pbxproj
@@ -641,6 +641,11 @@
 				);
 				LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_1 = "\"$(SRCROOT)/src/pugixmlLib\"";
 				LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_2 = "\"$(SRCROOT)/src/pugixmlLib/lib\"";
+				OTHER_CPLUSPLUSFLAGS = (
+					"-D__MACOSX_CORE__",
+					"-lpthread",
+					"-DMAKE_IOS",
+				);
 				PREBINDING = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)Debug";
 				WRAPPER_EXTENSION = app;
@@ -731,6 +736,11 @@
 				);
 				LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_1 = "\"$(SRCROOT)/src/pugixmlLib\"";
 				LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_2 = "\"$(SRCROOT)/src/pugixmlLib/lib\"";
+				OTHER_CPLUSPLUSFLAGS = (
+					"-D__MACOSX_CORE__",
+					"-lpthread",
+					"-DMAKE_IOS",
+				);
 				PREBINDING = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;

--- a/projectGenerator.xcodeproj/xcshareddata/xcschemes/projectGenerator.xcscheme
+++ b/projectGenerator.xcodeproj/xcshareddata/xcschemes/projectGenerator.xcscheme
@@ -22,8 +22,8 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
       <Testables>
@@ -39,11 +39,12 @@
       </MacroExpansion>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable>

--- a/src/addons/ofAddon.cpp
+++ b/src/addons/ofAddon.cpp
@@ -107,7 +107,7 @@ bool ofAddon::checkCorrectVariable(string variable, ConfigParseState state){
 	case AndroidARMv7:
 	case iOS:
 	case OSX:
-		return (variable == "ADDON_DEPENDENCIES" || variable == "ADDON_INCLUDES" || variable == "ADDON_CFLAGS" || variable == "ADDON_LDFLAGS"  || variable == "ADDON_LIBS" || variable == "ADDON_PKG_CONFIG_LIBRARIES" ||
+		return (variable == "ADDON_DEPENDENCIES" || variable == "ADDON_INCLUDES" || variable == "ADDON_CFLAGS" || variable == "ADDON_PURECFLAGS" || variable == "ADDON_LDFLAGS"  || variable == "ADDON_LIBS" || variable == "ADDON_PKG_CONFIG_LIBRARIES" ||
 				variable == "ADDON_FRAMEWORKS" || variable == "ADDON_SOURCES" || variable == "ADDON_DATA" || variable == "ADDON_LIBS_EXCLUDE" || variable == "ADDON_SOURCES_EXCLUDE" || variable == "ADDON_INCLUDES_EXCLUDE" || variable == "ADDON_DLLS_TO_COPY");
 	case Unknown:
 	default:
@@ -191,6 +191,10 @@ void ofAddon::parseVariableValue(string variable, string value, bool addToValue,
 
 	if(variable == "ADDON_CFLAGS"){
 		addReplaceStringVector(cflags,value,"",addToValue);
+	}
+
+	if(variable == "ADDON_PURECFLAGS"){
+		addReplaceStringVector(purecflags,value,"",addToValue);
 	}
 
 	if(variable == "ADDON_LDFLAGS"){

--- a/src/addons/ofAddon.cpp
+++ b/src/addons/ofAddon.cpp
@@ -107,7 +107,7 @@ bool ofAddon::checkCorrectVariable(string variable, ConfigParseState state){
 	case AndroidARMv7:
 	case iOS:
 	case OSX:
-		return (variable == "ADDON_DEPENDENCIES" || variable == "ADDON_INCLUDES" || variable == "ADDON_CFLAGS" || variable == "ADDON_PURECFLAGS" || variable == "ADDON_LDFLAGS"  || variable == "ADDON_LIBS" || variable == "ADDON_PKG_CONFIG_LIBRARIES" ||
+		return (variable == "ADDON_DEPENDENCIES" || variable == "ADDON_INCLUDES" || variable == "ADDON_CFLAGS" || variable == "ADDON_CPPFLAGS" || variable == "ADDON_LDFLAGS"  || variable == "ADDON_LIBS" || variable == "ADDON_PKG_CONFIG_LIBRARIES" ||
 				variable == "ADDON_FRAMEWORKS" || variable == "ADDON_SOURCES" || variable == "ADDON_DATA" || variable == "ADDON_LIBS_EXCLUDE" || variable == "ADDON_SOURCES_EXCLUDE" || variable == "ADDON_INCLUDES_EXCLUDE" || variable == "ADDON_DLLS_TO_COPY");
 	case Unknown:
 	default:
@@ -193,8 +193,8 @@ void ofAddon::parseVariableValue(string variable, string value, bool addToValue,
 		addReplaceStringVector(cflags,value,"",addToValue);
 	}
 
-	if(variable == "ADDON_PURECFLAGS"){
-		addReplaceStringVector(purecflags,value,"",addToValue);
+	if(variable == "ADDON_CPPFLAGS"){
+		addReplaceStringVector(cppflags,value,"",addToValue);
 	}
 
 	if(variable == "ADDON_LDFLAGS"){

--- a/src/addons/ofAddon.h
+++ b/src/addons/ofAddon.h
@@ -37,7 +37,7 @@ public:
     // From addon_config.mk
     vector < string > dependencies;
     vector < string > cflags;     // CXX_FLAGS
-	vector < string > purecflags; // C_FLAGS
+    vector < string > purecflags; // C_FLAGS
     vector < string > ldflags;
     vector < string > pkgConfigLibs; 	// linux only
     vector < string > frameworks;		// osx only

--- a/src/addons/ofAddon.h
+++ b/src/addons/ofAddon.h
@@ -36,7 +36,8 @@ public:
     
     // From addon_config.mk
     vector < string > dependencies;
-    vector < string > cflags;
+    vector < string > cflags;     // CXX_FLAGS
+	vector < string > purecflags; // C_FLAGS
     vector < string > ldflags;
     vector < string > pkgConfigLibs; 	// linux only
     vector < string > frameworks;		// osx only

--- a/src/addons/ofAddon.h
+++ b/src/addons/ofAddon.h
@@ -36,8 +36,8 @@ public:
     
     // From addon_config.mk
     vector < string > dependencies;
-    vector < string > cflags;     // CXX_FLAGS
-    vector < string > purecflags; // C_FLAGS
+    vector < string > cflags;   // C_FLAGS
+    vector < string > cppflags; // CXX_FLAGS
     vector < string > ldflags;
     vector < string > pkgConfigLibs; 	// linux only
     vector < string > frameworks;		// osx only

--- a/src/projects/baseProject.cpp
+++ b/src/projects/baseProject.cpp
@@ -145,6 +145,10 @@ void baseProject::addAddon(ofAddon & addon){
         ofLogVerbose() << "adding addon cflags: " << addon.cflags[i];
         addCFLAG(addon.cflags[i]);
     }
+	for(int i=0;i<(int)addon.purecflags.size();i++){
+        ofLogVerbose() << "adding addon pure cflags: " << addon.purecflags[i];
+        addPureCFLAG(addon.purecflags[i]);
+    }
     for(int i=0;i<(int)addon.ldflags.size();i++){
         ofLogVerbose() << "adding addon ldflags: " << addon.ldflags[i];
         addLDFLAG(addon.ldflags[i]);
@@ -154,20 +158,20 @@ void baseProject::addAddon(ofAddon & addon){
         addSrc(addon.srcFiles[i],addon.filesToFolders[addon.srcFiles[i]]);
     }
     for(int i=0;i<(int)addon.csrcFiles.size(); i++){
-        ofLogVerbose() << "adding addon c srcFiles: " << addon.srcFiles[i];
-        addSrc(addon.srcFiles[i],addon.filesToFolders[addon.srcFiles[i]],C);
+        ofLogVerbose() << "adding addon c srcFiles: " << addon.csrcFiles[i];
+        addSrc(addon.csrcFiles[i],addon.filesToFolders[addon.csrcFiles[i]],C);
     }
     for(int i=0;i<(int)addon.cppsrcFiles.size(); i++){
-        ofLogVerbose() << "adding addon c srcFiles: " << addon.srcFiles[i];
-        addSrc(addon.srcFiles[i],addon.filesToFolders[addon.srcFiles[i]],CPP);
+        ofLogVerbose() << "adding addon cpp srcFiles: " << addon.cppsrcFiles[i];
+        addSrc(addon.cppsrcFiles[i],addon.filesToFolders[addon.cppsrcFiles[i]],CPP);
     }
     for(int i=0;i<(int)addon.objcsrcFiles.size(); i++){
-        ofLogVerbose() << "adding addon c srcFiles: " << addon.srcFiles[i];
-        addSrc(addon.srcFiles[i],addon.filesToFolders[addon.srcFiles[i]],OBJC);
+        ofLogVerbose() << "adding addon objc srcFiles: " << addon.objcsrcFiles[i];
+        addSrc(addon.objcsrcFiles[i],addon.filesToFolders[addon.objcsrcFiles[i]],OBJC);
     }
     for(int i=0;i<(int)addon.headersrcFiles.size(); i++){
-        ofLogVerbose() << "adding addon c srcFiles: " << addon.srcFiles[i];
-        addSrc(addon.srcFiles[i],addon.filesToFolders[addon.srcFiles[i]],HEADER);
+        ofLogVerbose() << "adding addon header srcFiles: " << addon.headersrcFiles[i];
+        addSrc(addon.headersrcFiles[i],addon.filesToFolders[addon.headersrcFiles[i]],HEADER);
     }
 }
 

--- a/src/projects/baseProject.cpp
+++ b/src/projects/baseProject.cpp
@@ -145,9 +145,9 @@ void baseProject::addAddon(ofAddon & addon){
         ofLogVerbose() << "adding addon cflags: " << addon.cflags[i];
         addCFLAG(addon.cflags[i]);
     }
-	for(int i=0;i<(int)addon.purecflags.size();i++){
-        ofLogVerbose() << "adding addon pure cflags: " << addon.purecflags[i];
-        addPureCFLAG(addon.purecflags[i]);
+	for(int i=0;i<(int)addon.cppflags.size();i++){
+        ofLogVerbose() << "adding addon cppflags: " << addon.cppflags[i];
+        addCPPFLAG(addon.cppflags[i]);
     }
     for(int i=0;i<(int)addon.ldflags.size();i++){
         ofLogVerbose() << "adding addon ldflags: " << addon.ldflags[i];

--- a/src/projects/baseProject.h
+++ b/src/projects/baseProject.h
@@ -54,7 +54,8 @@ public:
     virtual void addInclude(string includeName) = 0;
     virtual void addLibrary(string libraryName, LibType libType = RELEASE_LIB) = 0;
     virtual void addLDFLAG(string ldflag, LibType libType = RELEASE_LIB){}
-    virtual void addCFLAG(string cflag, LibType libType = RELEASE_LIB){};
+    virtual void addCFLAG(string cflag, LibType libType = RELEASE_LIB){}; // CXX_FLAGS
+	virtual void addPureCFLAG(string purecflag, LibType libType = RELEASE_LIB){}; // C_FLAGS
 
 	virtual void addAddon(ofAddon & addon);
 

--- a/src/projects/baseProject.h
+++ b/src/projects/baseProject.h
@@ -54,8 +54,8 @@ public:
     virtual void addInclude(string includeName) = 0;
     virtual void addLibrary(string libraryName, LibType libType = RELEASE_LIB) = 0;
     virtual void addLDFLAG(string ldflag, LibType libType = RELEASE_LIB){}
-    virtual void addCFLAG(string cflag, LibType libType = RELEASE_LIB){}; // CXX_FLAGS
-    virtual void addPureCFLAG(string purecflag, LibType libType = RELEASE_LIB){}; // C_FLAGS
+    virtual void addCFLAG(string cflag, LibType libType = RELEASE_LIB){}; // C_FLAGS
+    virtual void addCPPFLAG(string cppflag, LibType libType = RELEASE_LIB){}; // CXX_FLAGS
 
 	virtual void addAddon(ofAddon & addon);
 

--- a/src/projects/baseProject.h
+++ b/src/projects/baseProject.h
@@ -55,7 +55,7 @@ public:
     virtual void addLibrary(string libraryName, LibType libType = RELEASE_LIB) = 0;
     virtual void addLDFLAG(string ldflag, LibType libType = RELEASE_LIB){}
     virtual void addCFLAG(string cflag, LibType libType = RELEASE_LIB){}; // CXX_FLAGS
-	virtual void addPureCFLAG(string purecflag, LibType libType = RELEASE_LIB){}; // C_FLAGS
+    virtual void addPureCFLAG(string purecflag, LibType libType = RELEASE_LIB){}; // C_FLAGS
 
 	virtual void addAddon(ofAddon & addon);
 

--- a/src/projects/visualStudioProject.cpp
+++ b/src/projects/visualStudioProject.cpp
@@ -308,6 +308,28 @@ void visualStudioProject::addCFLAG(string cflag, LibType libType){
 
 }
 
+void visualStudioProject::addPureCFLAG(string purecflag, LibType libType){
+	pugi::xpath_node_set items = doc.select_nodes("//ItemDefinitionGroup");
+	for(int i=0;i<items.size();i++){
+		pugi::xml_node additionalOptions;
+		bool found=false;
+		if(libType==RELEASE_LIB && string(items[i].node().attribute("Condition").value())=="'$(Configuration)|$(Platform)'=='Release|Win32'"){
+			additionalOptions = items[i].node().child("ClCompile").child("AdditionalOptions");
+			found = true;
+		}else if(libType==DEBUG_LIB && string(items[i].node().attribute("Condition").value())=="'$(Configuration)|$(Platform)'=='Debug|Win32'"){
+			additionalOptions = items[i].node().child("ClCompile").child("AdditionalOptions");
+			found = true;
+		}
+		if(!found) continue;
+		if(!additionalOptions){
+			items[i].node().child("ClCompile").append_child("AdditionalOptions").append_child(pugi::node_pcdata).set_value(purecflag.c_str());
+		}else{
+			additionalOptions.set_value((string(additionalOptions.value()) + " " + purecflag).c_str());
+		}
+	}
+
+}
+
 void visualStudioProject::addAddon(ofAddon & addon){
     for(int i=0;i<(int)addons.size();i++){
 		if(addons[i].name==addon.name) return;
@@ -410,19 +432,19 @@ void visualStudioProject::addAddon(ofAddon & addon){
     }
 
     for(int i=0;i<(int)addon.cppsrcFiles.size(); i++){
-        ofLogVerbose() << "adding addon c srcFiles: " << addon.cppsrcFiles[i];
+        ofLogVerbose() << "adding addon cpp srcFiles: " << addon.cppsrcFiles[i];
 		if(addon.filesToFolders[addon.cppsrcFiles[i]]=="") addon.filesToFolders[addon.cppsrcFiles[i]]="other";
         addSrc(addon.cppsrcFiles[i],addon.filesToFolders[addon.cppsrcFiles[i]],C);
     }
 
     for(int i=0;i<(int)addon.headersrcFiles.size(); i++){
-        ofLogVerbose() << "adding addon c srcFiles: " << addon.headersrcFiles[i];
+        ofLogVerbose() << "adding addon header srcFiles: " << addon.headersrcFiles[i];
 		if(addon.filesToFolders[addon.headersrcFiles[i]]=="") addon.filesToFolders[addon.headersrcFiles[i]]="other";
         addSrc(addon.headersrcFiles[i],addon.filesToFolders[addon.headersrcFiles[i]],C);
     }
 
     for(int i=0;i<(int)addon.objcsrcFiles.size(); i++){
-        ofLogVerbose() << "adding addon c srcFiles: " << addon.objcsrcFiles[i];
+        ofLogVerbose() << "adding addon objc srcFiles: " << addon.objcsrcFiles[i];
 		if(addon.filesToFolders[addon.objcsrcFiles[i]]=="") addon.filesToFolders[addon.objcsrcFiles[i]]="other";
         addSrc(addon.objcsrcFiles[i],addon.filesToFolders[addon.objcsrcFiles[i]],C);
     }
@@ -434,7 +456,14 @@ void visualStudioProject::addAddon(ofAddon & addon){
 	}
 
 	for(int i=0;i<(int)addon.cflags.size();i++){
+		ofLogVerbose() << "adding addon cflags: " << addon.cflags[i];
 		addCFLAG(addon.cflags[i],RELEASE_LIB);
 		addCFLAG(addon.cflags[i],DEBUG_LIB);
+	}
+	
+	for(int i=0;i<(int)addon.purecflags.size();i++){
+		ofLogVerbose() << "adding addon pure cflags: " << addon.purecflags[i];
+		addPureCFLAG(addon.purecflags[i],RELEASE_LIB);
+		addPureCFLAG(addon.purecflags[i],DEBUG_LIB);
 	}
 }

--- a/src/projects/visualStudioProject.cpp
+++ b/src/projects/visualStudioProject.cpp
@@ -308,7 +308,7 @@ void visualStudioProject::addCFLAG(string cflag, LibType libType){
 
 }
 
-void visualStudioProject::addPureCFLAG(string purecflag, LibType libType){
+void visualStudioProject::addCPPFLAG(string cppflag, LibType libType){
 	pugi::xpath_node_set items = doc.select_nodes("//ItemDefinitionGroup");
 	for(int i=0;i<items.size();i++){
 		pugi::xml_node additionalOptions;
@@ -322,9 +322,9 @@ void visualStudioProject::addPureCFLAG(string purecflag, LibType libType){
 		}
 		if(!found) continue;
 		if(!additionalOptions){
-			items[i].node().child("ClCompile").append_child("AdditionalOptions").append_child(pugi::node_pcdata).set_value(purecflag.c_str());
+			items[i].node().child("ClCompile").append_child("AdditionalOptions").append_child(pugi::node_pcdata).set_value(cppflag.c_str());
 		}else{
-			additionalOptions.set_value((string(additionalOptions.value()) + " " + purecflag).c_str());
+			additionalOptions.set_value((string(additionalOptions.value()) + " " + cppflag).c_str());
 		}
 	}
 
@@ -461,9 +461,9 @@ void visualStudioProject::addAddon(ofAddon & addon){
 		addCFLAG(addon.cflags[i],DEBUG_LIB);
 	}
 	
-	for(int i=0;i<(int)addon.purecflags.size();i++){
-		ofLogVerbose() << "adding addon pure cflags: " << addon.purecflags[i];
-		addPureCFLAG(addon.purecflags[i],RELEASE_LIB);
-		addPureCFLAG(addon.purecflags[i],DEBUG_LIB);
+	for(int i=0;i<(int)addon.cppflags.size();i++){
+		ofLogVerbose() << "adding addon cppflags: " << addon.cppflags[i];
+		addCPPFLAG(addon.cppflags[i],RELEASE_LIB);
+		addCPPFLAG(addon.cppflags[i],DEBUG_LIB);
 	}
 }

--- a/src/projects/visualStudioProject.h
+++ b/src/projects/visualStudioProject.h
@@ -22,7 +22,8 @@ public:
     void addSrc(string srcFile, string folder, SrcType type=DEFAULT);
     void addInclude(string includeName);
     void addLibrary(string libraryName, LibType libType);
-    void addCFLAG(string cflag, LibType libType = RELEASE_LIB);
+    void addCFLAG(string cflag, LibType libType = RELEASE_LIB); // C++
+	void addPureCFLAG(string purecflag, LibType libType = RELEASE_LIB); // C
 
     void addAddon(ofAddon & addon);
 

--- a/src/projects/visualStudioProject.h
+++ b/src/projects/visualStudioProject.h
@@ -23,7 +23,7 @@ public:
     void addInclude(string includeName);
     void addLibrary(string libraryName, LibType libType);
     void addCFLAG(string cflag, LibType libType = RELEASE_LIB); // C++
-	void addPureCFLAG(string purecflag, LibType libType = RELEASE_LIB); // C
+    void addPureCFLAG(string purecflag, LibType libType = RELEASE_LIB); // C
 
     void addAddon(ofAddon & addon);
 

--- a/src/projects/visualStudioProject.h
+++ b/src/projects/visualStudioProject.h
@@ -22,8 +22,8 @@ public:
     void addSrc(string srcFile, string folder, SrcType type=DEFAULT);
     void addInclude(string includeName);
     void addLibrary(string libraryName, LibType libType);
-    void addCFLAG(string cflag, LibType libType = RELEASE_LIB); // C++
-    void addPureCFLAG(string purecflag, LibType libType = RELEASE_LIB); // C
+    void addCFLAG(string cflag, LibType libType = RELEASE_LIB); // C
+    void addCPPFLAG(string cppflag, LibType libType = RELEASE_LIB); // C++
 
     void addAddon(ofAddon & addon);
 

--- a/src/projects/xcodeProject.cpp
+++ b/src/projects/xcodeProject.cpp
@@ -145,6 +145,16 @@ STRINGIFY(
 
 );
 
+//-----------------------------------------------------------------
+const char PureCFlags[] =
+STRINGIFY(
+
+          <key>OTHER_CFLAGS</key>
+          <array>
+          </array>
+
+);
+
 const char workspace[] =
 STRINGIFY(
 
@@ -921,7 +931,7 @@ void xcodeProject::addCFLAG(string cflag, LibType libType){
 
     } else {
 
-        //printf("we don't have OTHER_LDFLAGS, so we're adding them... and calling this function again \n");
+        //printf("we don't have OTHER_CPLUSPLUSFLAGS, so we're adding them... and calling this function again \n");
         sprintf(query, "//key[contains(.,'baseConfigurationReference')]/parent::node()//key[contains(.,'buildSettings')]/following-sibling::node()[1]");
 
         pugi::xpath_node_set dictArray = doc.select_nodes(query);
@@ -942,7 +952,49 @@ void xcodeProject::addCFLAG(string cflag, LibType libType){
         }
 
         // now that we have it, try again...
-        addLDFLAG(cflag);
+        addCFLAG(cflag);
+    }
+
+    //saveFile(projectDir + "/" + projectName + ".xcodeproj" + "/project.pbxproj");
+}
+
+void xcodeProject::addPureCFLAG(string purecflag, LibType libType){
+
+    char query[255];
+    sprintf(query, "//key[contains(.,'baseConfigurationReference')]/parent::node()//key[contains(.,'OTHER_CFLAGS')]/following-sibling::node()[1]");
+    pugi::xpath_node_set headerArray = doc.select_nodes(query);
+
+
+    if (headerArray.size() > 0){
+        for (pugi::xpath_node_set::const_iterator it = headerArray.begin(); it != headerArray.end(); ++it){
+            pugi::xpath_node node = *it;
+            node.node().append_child("string").append_child(pugi::node_pcdata).set_value(purecflag.c_str());
+        }
+
+    } else {
+
+        //printf("we don't have OTHER_CFLAGS, so we're adding them... and calling this function again \n");
+        sprintf(query, "//key[contains(.,'baseConfigurationReference')]/parent::node()//key[contains(.,'buildSettings')]/following-sibling::node()[1]");
+
+        pugi::xpath_node_set dictArray = doc.select_nodes(query);
+
+        for (pugi::xpath_node_set::const_iterator it = dictArray.begin(); it != dictArray.end(); ++it){
+            pugi::xpath_node node = *it;
+
+            //node.node().print(std::cout);
+            string ldXML = string(PureCFlags);
+            pugi::xml_document ldDoc;
+            pugi::xml_parse_result result = ldDoc.load_buffer(ldXML.c_str(), strlen(ldXML.c_str()));
+
+            // insert it at <plist><dict><dict>
+            node.node().prepend_copy(ldDoc.first_child().next_sibling());   // KEY FIRST
+            node.node().prepend_copy(ldDoc.first_child());                  // ARRAY SECOND
+
+            //node.node().print(std::cout);
+        }
+
+        // now that we have it, try again...
+        addPureCFLAG(purecflag);
     }
 
     //saveFile(projectDir + "/" + projectName + ".xcodeproj" + "/project.pbxproj");
@@ -967,6 +1019,10 @@ void xcodeProject::addAddon(ofAddon & addon){
     for(int i=0;i<(int)addon.cflags.size();i++){
         ofLogVerbose() << "adding addon cflags: " << addon.cflags[i];
         addCFLAG(addon.cflags[i]);
+    }
+	for(int i=0;i<(int)addon.purecflags.size();i++){
+        ofLogVerbose() << "adding addon pure cflags: " << addon.purecflags[i];
+        addPureCFLAG(addon.purecflags[i]);
     }
     for(int i=0;i<(int)addon.ldflags.size();i++){
         ofLogVerbose() << "adding addon ldflags: " << addon.ldflags[i];

--- a/src/projects/xcodeProject.h
+++ b/src/projects/xcodeProject.h
@@ -25,7 +25,8 @@ public:
     void addInclude(string includeName);
     void addLibrary(string libraryName, LibType libType = RELEASE_LIB);
     void addLDFLAG(string ldflag, LibType libType = RELEASE_LIB);
-    void addCFLAG(string cflag, LibType libType = RELEASE_LIB);
+    void addCFLAG(string cflag, LibType libType = RELEASE_LIB); // Other C++ Flags
+	void addPureCFLAG(string purecflag, LibType libType = RELEASE_LIB); // Other C Flags
     
     // specific to OSX
     void addFramework(string name, string path);

--- a/src/projects/xcodeProject.h
+++ b/src/projects/xcodeProject.h
@@ -26,7 +26,7 @@ public:
     void addLibrary(string libraryName, LibType libType = RELEASE_LIB);
     void addLDFLAG(string ldflag, LibType libType = RELEASE_LIB);
     void addCFLAG(string cflag, LibType libType = RELEASE_LIB); // Other C++ Flags
-	void addPureCFLAG(string purecflag, LibType libType = RELEASE_LIB); // Other C Flags
+    void addPureCFLAG(string purecflag, LibType libType = RELEASE_LIB); // Other C Flags
     
     // specific to OSX
     void addFramework(string name, string path);

--- a/src/projects/xcodeProject.h
+++ b/src/projects/xcodeProject.h
@@ -25,8 +25,8 @@ public:
     void addInclude(string includeName);
     void addLibrary(string libraryName, LibType libType = RELEASE_LIB);
     void addLDFLAG(string ldflag, LibType libType = RELEASE_LIB);
-    void addCFLAG(string cflag, LibType libType = RELEASE_LIB); // Other C++ Flags
-    void addPureCFLAG(string purecflag, LibType libType = RELEASE_LIB); // Other C Flags
+    void addCFLAG(string cflag, LibType libType = RELEASE_LIB); // Other C Flags
+    void addCPPFLAG(string cppflag, LibType libType = RELEASE_LIB); // Other C++ Flags
     
     // specific to OSX
     void addFramework(string name, string path);

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -389,7 +389,7 @@ void getLibsRecursively(const string & path, vector < string > & libFiles, vecto
 							}
 						}
 					}
-                } else if (ext == "h" || ext == "hpp" || ext == "c" || ext == "cpp" || ext == "cc"){
+                } else if (ext == "h" || ext == "hpp" || ext == "c" || ext == "cpp" || ext == "cc" || ext == "cxx" || ext == "m" || ext == "mm"){
                     libFiles.push_back(dir.getPath(i));
                 }
                 


### PR DESCRIPTION
Added support to parse a ADDON_PURECFLAGS variable which sets C flags (not CXX_FLAGS). This is mainly needed for Xcode and it sets the Other C Flags so defines can be set when compiling pure C sources. I also added support to Visual Studio projects where it simply adds them to the same line as the C++ flags (`\cl` I believe). Tested and working on Xcode, so now generated ofxPd projects can actually build. I'll add support for this flag to the Makefiles next.

Also fixed some wrong variables and prints which looked like they were left over from copy/pasting and not updated.