### PR TITLE
Remove MAKE_IOS define from xcode config

### DIFF
--- a/projectGenerator.xcodeproj/project.pbxproj
+++ b/projectGenerator.xcodeproj/project.pbxproj
@@ -644,7 +644,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D__MACOSX_CORE__",
 					"-lpthread",
-					"-DMAKE_IOS",
 				);
 				PREBINDING = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)Debug";
@@ -739,7 +738,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D__MACOSX_CORE__",
 					"-lpthread",
-					"-DMAKE_IOS",
 				);
 				PREBINDING = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
This fixes #67 by removing the problematic define. I guess in the future it would be nice to have a way to select two targets - one which compiles a project generator for OSX projects, one a generator for iOS projects. Unfortunately, my Xcode-fu isn't good enough to know how to handle this... :(
